### PR TITLE
fix: updating script cleanup string to remove the 'script(API)' if present

### DIFF
--- a/bin/extract-extension.js
+++ b/bin/extract-extension.js
@@ -23,7 +23,7 @@ function setUpService(debug) {
 }
 
 function cleanUpScriptString(script) {
-  return script.replace(/((?:function)?\s?\((\w+[,]?\s?)+\)\s?(?:=>)?\s?{((.|\n|\r)*(?=}))})?/, '$3').trim();
+  return script.replace(/((?:function)?(?:script)?\s?\((\w+[,]?\s?)+\)\s?(?:=>)?\s?{((.|\n|\r)*(?=}))})?/, '$3').trim();
 }
 
 const extract = (callback) => {


### PR DESCRIPTION
Issue encountered when specifying any interaction script param in the form:
`script(API: FieldInteractionAPI) {`

This would transpile to:
`script(API) {`

This transpiled javascript was not getting removed at the beginning of interactions.