### PR TITLE
SOLEN-2661: Apply regression fix to Custom Objects

### DIFF
--- a/bin/custom-objects-interaction-deploy-service.js
+++ b/bin/custom-objects-interaction-deploy-service.js
@@ -111,7 +111,11 @@ function deploySelectedCOFieldInteractions(selectiveExtensions, extensions) {
                         const extensionFI = extensions.customObjectFieldInteractions[extentionCO].find(fi => interaction.name === fi.name && fieldKey.toLowerCase() === fi.fieldName.toLowerCase());
                         if (extensionFI) {
                           const {privateLabelIds} = extensionFI;
-                          promiseList.push(custObjInteRestSvc.updateFieldInteraction(extensionFI, entity, extentionCO, fieldKey, interaction, objectUrl));
+                          if (!privateLabelIds || privateLabelIds.includes(privateLabelId.toString())) {
+                            promiseList.push(custObjInteRestSvc.updateFieldInteraction(extensionFI, entity, extentionCO, fieldKey, interaction, objectUrl));
+                          } else {
+                            logger.info(`Field Interaction ${interaction.name} skipped for Private Label ID ${privateLabelId}`);
+                          }
                         } else {
                           logger.warn(chalk.yellow(`Can't find '${interaction.name}' for '${extentionCO} - ${fieldKey}' in extentions file Field interaction will not be deployed!`));
                           results.push(resultsSvc.handleUpdateCOFIFail(entity, extentionCO, fieldKey, interactionName,
@@ -130,7 +134,11 @@ function deploySelectedCOFieldInteractions(selectiveExtensions, extensions) {
                         extensions.customObjectFieldInteractions[extentionCO]
                         if (extensionFI) {
                           const {privateLabelIds} = extensionFI;
-                          promiseList.push(custObjInteRestSvc.AddFieldInteraction(extensionFI, entity, extentionCO, fieldKey, uploadConfig[extentionCO].toAdd[fieldKey].fieldMapId, interactionName, objectUrl));
+                          if (!privateLabelIds || privateLabelIds.includes(privateLabelId.toString())) {
+                            promiseList.push(custObjInteRestSvc.AddFieldInteraction(extensionFI, entity, extentionCO, fieldKey, uploadConfig[extentionCO].toAdd[fieldKey].fieldMapId, interactionName, objectUrl));
+                          } else {
+                            logger.info(`Field Interaction ${interaction.name} skipped for Private Label ID ${privateLabelId}`);
+                          }
                         } else {
                           logger.warn(chalk.yellow(`Can't find '${interactionName}' for '${fieldKey}' in extentions file Field interaction will not be deployed!`));
                           results.push(resultsSvc.handleAddCOFIFail(entity, extentionCO, fieldKey, interactionName,

--- a/bin/custom-objects-interaction-deploy-service.js
+++ b/bin/custom-objects-interaction-deploy-service.js
@@ -110,6 +110,7 @@ function deploySelectedCOFieldInteractions(selectiveExtensions, extensions) {
                       uploadConfig[extentionCO].toUpdate[fieldKey].interactionNameID.forEach(interaction => {
                         const extensionFI = extensions.customObjectFieldInteractions[extentionCO].find(fi => interaction.name === fi.name && fieldKey.toLowerCase() === fi.fieldName.toLowerCase());
                         if (extensionFI) {
+                          const {privateLabelIds} = extensionFI;
                           promiseList.push(custObjInteRestSvc.updateFieldInteraction(extensionFI, entity, extentionCO, fieldKey, interaction, objectUrl));
                         } else {
                           logger.warn(chalk.yellow(`Can't find '${interaction.name}' for '${extentionCO} - ${fieldKey}' in extentions file Field interaction will not be deployed!`));
@@ -128,6 +129,7 @@ function deploySelectedCOFieldInteractions(selectiveExtensions, extensions) {
                         const extensionFI = extensions.customObjectFieldInteractions[extentionCO].find(fi => interactionName === fi.name && fieldKey.toLowerCase() === fi.fieldName.toLowerCase());
                         extensions.customObjectFieldInteractions[extentionCO]
                         if (extensionFI) {
+                          const {privateLabelIds} = extensionFI;
                           promiseList.push(custObjInteRestSvc.AddFieldInteraction(extensionFI, entity, extentionCO, fieldKey, uploadConfig[extentionCO].toAdd[fieldKey].fieldMapId, interactionName, objectUrl));
                         } else {
                           logger.warn(chalk.yellow(`Can't find '${interactionName}' for '${fieldKey}' in extentions file Field interaction will not be deployed!`));
@@ -251,7 +253,12 @@ function deployAllCOFieldInteractions(extensions) {
                       uploadConfig[extentionCO].toUpdate[fieldKey].interactionNameID.forEach(interaction => {
                         const extensionFI = extensions.customObjectFieldInteractions[extentionCO].find(fi => interaction.name === fi.name && fieldKey.toLowerCase() === fi.fieldName.toLowerCase());
                         if (extensionFI) {
-                          promiseList.push(custObjInteRestSvc.updateFieldInteraction(extensionFI, entity, extentionCO, fieldKey, interaction, objectUrl));
+                          const {privateLabelIds} = extensionFI;
+                          if (!privateLabelIds || privateLabelIds.includes(privateLabelId.toString())) {
+                            promiseList.push(custObjInteRestSvc.updateFieldInteraction(extensionFI, entity, extentionCO, fieldKey, interaction, objectUrl));
+                          } else {
+                            logger.info(`Field Interaction ${interaction.name} skipped for Private Label ID ${privateLabelId}`);
+                          }
                         } else {
                           logger.warn(chalk.yellow(`Can't find '${interaction.name}' for '${extentionCO} - ${fieldKey}' in extentions file Field interaction will not be deployed!`));
                           results.push(resultsSvc.handleUpdateCOFIFail(entity, extentionCO, fieldKey, interactionName,
@@ -269,7 +276,12 @@ function deployAllCOFieldInteractions(extensions) {
                         const extensionFI = extensions.customObjectFieldInteractions[extentionCO].find(fi => interactionName === fi.name && fieldKey.toLowerCase() === fi.fieldName.toLowerCase());
                         extensions.customObjectFieldInteractions[extentionCO]
                         if (extensionFI) {
-                          promiseList.push(custObjInteRestSvc.AddFieldInteraction(extensionFI, entity, extentionCO, fieldKey, uploadConfig[extentionCO].toAdd[fieldKey].fieldMapId, interactionName, objectUrl));
+                          const {privateLabelIds} = extensionFI;
+                          if (!privateLabelIds || privateLabelIds.includes(privateLabelId.toString())) {
+                            promiseList.push(custObjInteRestSvc.AddFieldInteraction(extensionFI, entity, extentionCO, fieldKey, uploadConfig[extentionCO].toAdd[fieldKey].fieldMapId, interactionName, objectUrl));
+                          } else {
+                            logger.info(`Field Interaction ${interaction.name} skipped for Private Label ID ${privateLabelId}`);
+                          }
                         } else {
                           logger.warn(chalk.yellow(`Can't find '${interactionName}' for '${fieldKey}' in extentions file Field interaction will not be deployed!`));
                           results.push(resultsSvc.handleAddCOFIFail(entity, extentionCO, fieldKey, interactionName,

--- a/bin/field-interaction-deploy-service.js
+++ b/bin/field-interaction-deploy-service.js
@@ -187,6 +187,7 @@ function deployAllFieldInteractions(privateLabelId, extensions) {
                     uploadConfig[entity].toUpdate[fieldKey].interactionNameID.forEach(interaction => {
                       const extensionFI = extensions.fieldInteractions[entity].find(fi => interaction.name === fi.name && fieldKey.toLowerCase() === fi.fieldName.toLowerCase());
                       if (extensionFI) {
+                        const {privateLabelIds} = extensionFI;
                         if (!privateLabelIds || privateLabelIds.includes(privateLabelId.toString())) {
                           promiseList.push(fieldInteRestSvc.updateFieldInteraction(extensionFI, entity, fieldKey, interaction));
                         } else {


### PR DESCRIPTION
Continuation of !66, where it was noticed the fix was missing for custom objects.